### PR TITLE
Update Files/config/package-lists/xbmc.list.chroot

### DIFF
--- a/Files/config/package-lists/xbmc.list.chroot
+++ b/Files/config/package-lists/xbmc.list.chroot
@@ -21,6 +21,9 @@ xbmcbuntu-plymouth-theme
 # Required by YouTube addon
 python-pysqlite2
 
+# Required by network-manager addon
+python-dbus
+
 # Required by wunderground
 python-simplejson
 


### PR DESCRIPTION
python-dbus needed for add-ons to communicate with dbus.
network-manager add-on is not working in RC1 due to this dependency.
