### PR TITLE
Remove deprecated options in 304.43 Version of NVidia driver

### DIFF
--- a/Files/config/includes.chroot/etc/xbmc/setup.d/01-configureXorg.sh
+++ b/Files/config/includes.chroot/etc/xbmc/setup.d/01-configureXorg.sh
@@ -71,7 +71,7 @@ if [ "$GPUTYPE" = "NVIDIA" ]; then
 	ldconfig
 
 	# run nvidia-xconfig
-	/usr/bin/nvidia-xconfig -s --no-logo --no-composite --no-dynamic-twinview --flatpanel-properties="Scaling = Native" --force-generate
+	/usr/bin/nvidia-xconfig -s --no-logo --no-composite --no-dynamic-twinview --force-generate
 
 	if [ "$xbmcParams" != "${xbmcParams%setdpi*}" ] ; then
 		echo "--set DPI" >> /tmp/debugInfo.txt


### PR DESCRIPTION
--flatpanel-properties="Scaling = Native" is no longer.
