### PR TITLE
Remove old scaling=native

### DIFF
--- a/Files/config/includes.chroot/etc/xbmc/setup.d/01-configureXorg.sh
+++ b/Files/config/includes.chroot/etc/xbmc/setup.d/01-configureXorg.sh
@@ -71,7 +71,7 @@ if [ "$GPUTYPE" = "NVIDIA" ]; then
 	ldconfig
 
 	# run nvidia-xconfig
-	/usr/bin/nvidia-xconfig -s --no-logo --no-composite --no-dynamic-twinview --flatpanel-properties="Scaling = Native" --force-generate
+	/usr/bin/nvidia-xconfig -s --no-logo --no-composite --no-dynamic-twinview --force-generate
 
 	if [ "$xbmcParams" != "${xbmcParams%setdpi*}" ] ; then
 		echo "--set DPI" >> /tmp/debugInfo.txt


### PR DESCRIPTION
--flatpanel-properties="Scaling = Native"

Comaptibility is broken with 3xx.xx Drivers
