### PR TITLE
use latest live build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,7 +96,7 @@ if ! which lb > /dev/null ; then
 	if [ ! -d live-build ]; then
 		repoURL="http://live.debian.net/archive/packages/live-build/orig/"
 		if [ -z "$SDK_USELATESTLIVEBUILD" ]; then
-		    latestPackage="live-build_3.0~a61.orig.tar.xz"
+		    latestPackage="live-build_4.0~a12.orig.tar.xz"
 		else
 		    latestPackage=$(curl -x "" -s -f $repoURL | grep live-build | tail -1 | grep -o '"live-build_[^"]*.tar..z"' | sed -e "s/\"//g")
 		fi


### PR DESCRIPTION
When latest is some specific version live-build_4.0~a12.orig.tar.xz and presumed best

Just a suggestion. @lcapriotti 
