### PR TITLE
Add pastebinit to ease providing logs

### DIFF
--- a/Files/config/package-lists/base.list.chroot
+++ b/Files/config/package-lists/base.list.chroot
@@ -25,3 +25,4 @@ python-software-properties
 policykit-desktop-privileges
 
 gdb
+pastebinit


### PR DESCRIPTION
e.g. cat path/to/whatever.log | pastebinit is oone example but it can be used to grab logs from any files to pastebin auto as you guys know.

useful from debug and others.
