### PR TITLE
Never show Grub menu for xbmcbuntu

### DIFF
--- a/CustomPackages/xbmcbuntu-initscripts/etc/xbmc/setup.d/18-setGrub
+++ b/CustomPackages/xbmcbuntu-initscripts/etc/xbmc/setup.d/18-setGrub
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 echo "GRUB_GFXPAYLOAD_LINUX=keep" >> /etc/default/grub 
+echo "GRUB_RECORDFAIL_TIMEOUT=0" >> /etc/default/grub
 update-grub
 
 exit 0


### PR DESCRIPTION
Prevent the boot from waiting for keyboard input on boot after shutdown failures. There are a lot of systems out there without an attached keyboard. In the grub documentation it is recommended for headless and appliance systems to change that value from the default value -1.
