### PR TITLE
Removing hardcoded netbios name 

### DIFF
--- a/buildDEBs/kodibuntu-initscripts/etc/kodi/setup.d/10-configureSamba.sh
+++ b/buildDEBs/kodibuntu-initscripts/etc/kodi/setup.d/10-configureSamba.sh
@@ -37,7 +37,6 @@ cat > /etc/samba/smb.conf << EOF
 [global]
 workgroup = WORKGROUP
 server string = %h server (Samba, KODI)
-netbios name = KODIbuntu
 dns proxy = no
 name resolve order = hosts wins bcast
 guest account = $kodiUser


### PR DESCRIPTION
Removing hardcoded netbios name, by default the first part of the hostname will be used. This will resolve conflicts due to multiple installations on the same network
